### PR TITLE
[CHORE] 앱 실행 환경에 따라 광고 ID 분리 (#21)

### DIFF
--- a/acon-mini-app/src/hooks/useInterstitialAd.ts
+++ b/acon-mini-app/src/hooks/useInterstitialAd.ts
@@ -1,11 +1,12 @@
 import { useCallback, useRef, useState } from 'react';
 
 import { useFocusEffect } from '@granite-js/native/@react-navigation/native';
-import { GoogleAdMob } from '@apps-in-toss/framework';
+import { GoogleAdMob, getOperationalEnvironment } from '@apps-in-toss/framework';
 
 import { SECRET_CONFIG } from 'config/secretConfig';
 
-const AD_GROUP_ID = SECRET_CONFIG.AD_GROUP_ID;
+const isSandbox = getOperationalEnvironment() === 'sandbox';
+const AD_GROUP_ID = isSandbox ? SECRET_CONFIG.AD_GROUP_ID_SANDBOX : SECRET_CONFIG.AD_GROUP_ID_PRODUCTION;
 
 export function useInterstitialAd() {
   const [loading, setLoading] = useState(true);


### PR DESCRIPTION
# 🐿️ *Pull Requests* 

## 🪵 **작업 브랜치**
- Resolved: #21 

## 🥔 **작업 내용**
<!-- 작업 내용을 적어주세요. -->
- `getOperationalEnvironment`로 실행 환경 확인하여 광고 ID 분리
  - `sandbox`: test ID
  - `그 외`: 실제 ID
    - QR test (intoss-private://)
    - 실제 출시 버전

## 💥 To be sure
- [x] 모든 뷰가 잘 실행되는지 다시 한 번 체크해주세요 !
